### PR TITLE
make token cache freeable

### DIFF
--- a/PHP/Token/Stream.php
+++ b/PHP/Token/Stream.php
@@ -286,6 +286,13 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
         }
     }
 
+    public function __destruct()
+    {
+        for ($i = 0; $i < count($this->tokens); $i++) {
+            unset($this->tokens[$i]);
+        }
+    }
+
     /**
      * @return array
      */

--- a/PHP/Token/Stream/CachingFactory.php
+++ b/PHP/Token/Stream/CachingFactory.php
@@ -72,4 +72,9 @@ class PHP_Token_Stream_CachingFactory
 
         return self::$cache[$filename];
     }
+
+    public static function unsetFromCache($filename)
+    {
+        self::$cache[$filename] = null;
+    }
 }


### PR DESCRIPTION
This patch makes it possible to unset the token stream object from cache, so it can be unset properly. The destructor unsets the token objects, so memory is actually is freed.

The patch in my pull request in php-code-coverage ([Link](https://github.com/sebastianbergmann/php-code-coverage/pull/43)) calls this method when the cache is not needed anymore, before it unsets the token stream object. This way the performance benefits of the token cache are kept, and memory is freed after the cache is not needed.

This have reduced memory usage to its third on our project (from 1.2Gb).
