### PR TITLE
Added the ability to delete a file from the cache.

### DIFF
--- a/PHP/Token/Stream/CachingFactory.php
+++ b/PHP/Token/Stream/CachingFactory.php
@@ -61,6 +61,13 @@ class PHP_Token_Stream_CachingFactory
     protected static $cache = array();
 
     /**
+     * @param string $filename
+     */
+    public function delete($filename) {
+        unset(self::$cache[$filename]);
+    }
+
+    /**
      * @param  string $filename
      * @return PHP_Token_Stream
      */


### PR DESCRIPTION
It's nice to be able to remove entries from the cache so memory usage doesn't grow too large.  I added this functionality to fix memory usage problems in php-code-coverage.  I will be submitting a php-code-coverage pull request shortly. I paired on this work with my coworker, Mark French.
