### PR TITLE
Classes now can find out in what namespace they where created

### DIFF
--- a/PHP/Token.php
+++ b/PHP/Token.php
@@ -639,8 +639,8 @@ class PHP_Token_NAMESPACE extends PHP_Token
     public function getName()
     {
         $tokens    = $this->tokenStream->tokens();
-        $namespace = '';
-        for ($i = $this->id + 2; ; $i += 2) {
+        $namespace = (string)$tokens[$this->id+2];
+        for ($i = $this->id + 3; ; $i += 2) {
             if (isset($tokens[$i]) &&
                 $tokens[$i] instanceof PHP_Token_NS_SEPARATOR) {
                 $namespace .= '\\' . $tokens[$i+1];

--- a/Tests/Token/InterfaceTest.php
+++ b/Tests/Token/InterfaceTest.php
@@ -164,7 +164,7 @@ class PHP_Token_InterfaceTest extends PHPUnit_Framework_TestCase
         foreach($tokenStream as $token) {
             if($token instanceOf PHP_Token_INTERFACE) {
                 $package = $token->getPackage();
-                $this->assertSame('\\Foo\\Bar', $package['namespace']);
+                $this->assertSame('Foo\\Bar', $package['namespace']);
             }
         }
     }
@@ -188,7 +188,7 @@ class PHP_Token_InterfaceTest extends PHPUnit_Framework_TestCase
             if($firstClassFound === false && $token instanceOf PHP_Token_INTERFACE) {
                 $package = $token->getPackage();
                 $this->assertSame('TestClassInBar', $token->getName());
-                $this->assertSame('\\Foo\\Bar', $package['namespace']);
+                $this->assertSame('Foo\\Bar', $package['namespace']);
                 $firstClassFound = true;
                 continue;
             }
@@ -196,7 +196,7 @@ class PHP_Token_InterfaceTest extends PHPUnit_Framework_TestCase
             if($token instanceOf PHP_Token_INTERFACE) {
                 $package = $token->getPackage();
                 $this->assertSame('TestClassInBaz', $token->getName());
-                $this->assertSame('\\Foo\\Bar', $package['namespace']);
+                $this->assertSame('Foo\\Bar', $package['namespace']);
                 return;
             }
         }

--- a/Tests/Token/NamespaceTest.php
+++ b/Tests/Token/NamespaceTest.php
@@ -74,7 +74,7 @@ class PHP_Token_NamespaceTest extends PHPUnit_Framework_TestCase
         $tokenStream = new PHP_Token_Stream(TEST_FILES_PATH . 'classInNamespace.php');
         foreach($tokenStream as $token) {
             if($token instanceOf PHP_Token_NAMESPACE) {
-                $this->assertSame('\\Foo\\Bar', $token->getName());
+                $this->assertSame('Foo\\Bar', $token->getName());
             }
         }
     }

--- a/Tests/_files/classInNamespace.php
+++ b/Tests/_files/classInNamespace.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace \Foo\Bar;
+namespace Foo\Bar;
 
 class TestClass {
 

--- a/Tests/_files/multipleNamespacesWithOneClassUsingBraces.php
+++ b/Tests/_files/multipleNamespacesWithOneClassUsingBraces.php
@@ -1,12 +1,12 @@
 <?php
 
-namespace \Foo\Bar;
+namespace Foo\Bar;
 
 class TestClassInBar {
 
 }
 
-namespace \Foo\Baz;
+namespace Foo\Baz;
 
 class TestClassInBaz {
 

--- a/Tests/_files/multipleNamespacesWithOneClassUsingNonBraceSyntax.php
+++ b/Tests/_files/multipleNamespacesWithOneClassUsingNonBraceSyntax.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace \Foo\Bar {
+namespace Foo\Bar {
 
     class TestClassInBar {
 
@@ -8,7 +8,7 @@ namespace \Foo\Bar {
 
 }
 
-namespace \Foo\Baz {
+namespace Foo\Baz {
 
     class TestClassInBaz {
 


### PR DESCRIPTION
$class->getPackage()['namespace']  now contains the namespace the class was defined in like you said it should on irc. 

Added tests for all the code i touched.
