### PR TITLE
Fixes namespace detection in a file with mutileplace namespaces

### DIFF
--- a/PHP/Token.php
+++ b/PHP/Token.php
@@ -520,6 +520,7 @@ class PHP_Token_INTERFACE extends PHP_TokenWithScope
         for($i = $this->id; $i; --$i) {
             if($this->tokenStream[$i] instanceof PHP_Token_NAMESPACE) {
                 $result['namespace'] = $this->tokenStream[$i]->getName();
+                break;
             }
         }
 

--- a/Tests/Token/InterfaceTest.php
+++ b/Tests/Token/InterfaceTest.php
@@ -196,7 +196,7 @@ class PHP_Token_InterfaceTest extends PHPUnit_Framework_TestCase
             if($token instanceOf PHP_Token_INTERFACE) {
                 $package = $token->getPackage();
                 $this->assertSame('TestClassInBaz', $token->getName());
-                $this->assertSame('Foo\\Bar', $package['namespace']);
+                $this->assertSame('Foo\\Baz', $package['namespace']);
                 return;
             }
         }
@@ -225,8 +225,10 @@ class PHP_Token_InterfaceTest extends PHPUnit_Framework_TestCase
                 continue;
             }
             if($token instanceOf PHP_Token_INTERFACE) {
+                var_dump("SECOND");
+                $package = $token->getPackage();
                 $this->assertSame('Extender', $token->getName());
-                $this->assertSame('Other\\Namespace', $package['namespace']);
+                $this->assertSame('Other\\Space', $package['namespace']);
                 return;
             }
         }

--- a/Tests/_files/classExtendsNamespacedClass.php
+++ b/Tests/_files/classExtendsNamespacedClass.php
@@ -4,7 +4,7 @@ namespace Foo\Bar;
 
 class Baz {}
 
-namespace Other\Namespace;
+namespace Other\Space;
 
 class Extender extends \Foo\Bar\Baz {}
 


### PR DESCRIPTION
If a file had more than one namespace it would always detect the upper most namespace in the file.

The test i created for that was broken too :)

By introducing the "break" in PHP/Token.php that gets fixed.
