### PR TITLE
composer support now uses classmap autoloading

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,6 @@
             "role": "lead"
         }
     ],
-    "version": "1.1.4",
-    "time": "2012-09-23",
     "support": {
         "issues": "https://github.com/sebastianbergmann/php-token-stream/issues",
         "irc": "irc://irc.freenode.net/phpunit"
@@ -25,8 +23,8 @@
         "ext-tokenizer": "*"
     },
     "autoload": {
-        "files": [
-            "PHP/Token/Stream/Autoload.php"
+        "classmap": [
+            "PHP/"
         ]
     },
     "include-path": [

--- a/package-composer.json
+++ b/package-composer.json
@@ -9,9 +9,11 @@
         "irc": "irc://irc.freenode.net/phpunit"
     },
     "autoload": {
-        "files": [ "PHP/Token/Stream/Autoload.php" ]
+        "classmap": [ "PHP/" ]
     },
     "include_path": [
         ""
-    ]
+    ],
+    "version": false,
+    "time": false
 }


### PR DESCRIPTION
package2composer should do the right thing with this change in dev and stable branches.
