### PR TITLE
PHP_Token_FUNCTION::getName sometimes returns the wrong name

### DIFF
--- a/PHP/Token.php
+++ b/PHP/Token.php
@@ -404,17 +404,22 @@ class PHP_Token_FUNCTION extends PHP_TokenWithScopeAndVisibility
 
         $tokens = $this->tokenStream->tokens();
 
-        if ($tokens[$this->id+2] instanceof PHP_Token_STRING) {
-            $this->name = (string)$tokens[$this->id+2];
-        }
+        for ($i = $this->id + 1; $i < count($tokens); $i++) {
+            if ($tokens[$i] instanceof PHP_Token_STRING) {
+                $this->name = (string)$tokens[$i];
+                break;
+            }
 
-        else if ($tokens[$this->id+2] instanceof PHP_Token_AMPERSAND &&
-                 $tokens[$this->id+3] instanceof PHP_Token_STRING) {
-            $this->name = (string)$tokens[$this->id+3];
-        }
+            else if ($tokens[$i] instanceof PHP_Token_AMPERSAND &&
+                     $tokens[$i+1] instanceof PHP_Token_STRING) {
+                $this->name = (string)$tokens[$i+1];
+                break;
+            }
 
-        else {
-            $this->name = 'anonymous function';
+            else if ($tokens[$i] instanceof PHP_Token_OPEN_BRACKET) {
+                $this->name = 'anonymous function';
+                break;
+            }
         }
 
         if ($this->name != 'anonymous function') {

--- a/Tests/Token/ClosureTest.php
+++ b/Tests/Token/ClosureTest.php
@@ -84,7 +84,7 @@ class PHP_Token_ClosureTest extends PHPUnit_Framework_TestCase
      */
     public function testGetArguments()
     {
-        $this->assertEquals(array('$foo' => null, '$bar' => null), $this->functions[0]->getArguments());
+        $this->assertEquals(array('$foo' => 'Exception', '$bar' => null), $this->functions[0]->getArguments());
         $this->assertEquals(array('$foo' => null, '$bar' => null, '$baz' => null), $this->functions[1]->getArguments());
         $this->assertEquals(array(), $this->functions[2]->getArguments());
         $this->assertEquals(array(), $this->functions[3]->getArguments());

--- a/Tests/_files/closure.php
+++ b/Tests/_files/closure.php
@@ -1,5 +1,5 @@
 <?php
-$function1 = function($foo, $bar) use ($var) {};
+$function1 = function(Exception $foo, $bar) use ($var) {};
 $function2 = function ($foo, $bar, $baz) {};
 $function3 = function () {};
 $function4 = function() {};


### PR DESCRIPTION
Given the following code:

``` php
<?php
$class = '<?php
function foo(Exception $e) {}
$func = function(Exception $e) {};';
$stream = new PHP_Token_Stream($class);

foreach ($stream->tokens() as $token) {
    if ($token instanceof PHP_Token_FUNCTION) {
        echo $token->getName() . PHP_EOL;
    }
}
```

the output is:

```
foo
Exception
```

when it should be:

```
foo
anonymous function
```

This PR should fix this issue by changing the way the `getName()` method finds the function name.
