### PR TITLE
Fix for Issue #31: function name used as typehint for first argment

### DIFF
--- a/PHP/Token.php
+++ b/PHP/Token.php
@@ -376,9 +376,14 @@ class PHP_Token_FUNCTION extends PHP_TokenWithScopeAndVisibility
         }
 
         $this->arguments = array();
-        $i               = $this->id + 2;
         $tokens          = $this->tokenStream->tokens();
         $typeHint        = NULL;
+
+        // Search for first token inside brackets
+        $i = $this->id + 2;
+        while (!$tokens[$i-1] instanceof PHP_Token_OPEN_BRACKET) {
+            $i++;
+        }
 
         while (!$tokens[$i] instanceof PHP_Token_CLOSE_BRACKET) {
             if ($tokens[$i] instanceof PHP_Token_STRING) {

--- a/Tests/Token/FunctionTest.php
+++ b/Tests/Token/FunctionTest.php
@@ -99,6 +99,8 @@ class PHP_Token_FunctionTest extends PHPUnit_Framework_TestCase
         );
 
         $this->assertEquals(array(), $this->functions[4]->getArguments());
+
+        $this->assertEquals(array('$x' => null, '$y' => null), $this->functions[5]->getArguments());
     }
 
     /**

--- a/Tests/_files/source.php
+++ b/Tests/_files/source.php
@@ -29,4 +29,8 @@ class Foo{function foo(){}
     public function baz()
     {
     }
+
+    public function blaz($x, $y)
+    {
+    }
 }


### PR DESCRIPTION
fix for issue #31
function::getArguments:
fixed function name mistakenly used as typehint for first typehint-less argument
