### PR TITLE
Define composer test script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - composer install --no-interaction --prefer-source --dev
 
 script:
-  - ./vendor/bin/phpunit --configuration ./build/phpunit.xml
+  - composer test
 
 matrix:
   allow_failures:

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,9 @@
     "support": {
         "issues": "https://github.com/sebastianbergmann/php-token-stream/issues"
     },
+    "scripts": {
+        "test": "phpunit --configuration ./build/phpunit.xml"
+    },
     "require": {
         "php": ">=5.3.3",
         "ext-tokenizer": "*"


### PR DESCRIPTION
The composer test script is an easy and convenient way to define your unit
testing scripts. It makes testing your library as easy as just running
`composer test`.

For more information about the `scripts` field check out [the manual](https://getcomposer.org/doc/articles/scripts.md) and [this blog post](http://maxgfeller.com/blog/2014/07/22/composer-test/).