### PR TITLE
Add PHP_Token_IN and PHP_Token_JOIN to the list of tokens introduced in HackLang.

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -719,3 +719,5 @@ class PHP_Token_SHAPE extends PHP_Token {}
 class PHP_Token_LAMBDA_OP extends PHP_Token {}
 class PHP_Token_LAMBDA_CP extends PHP_Token {}
 class PHP_Token_LAMBDA_ARROW extends PHP_Token {}
+class PHP_Token_IN extends PHP_Token {}
+class PHP_Token_JOIN extends PHP_Token {}


### PR DESCRIPTION
I am unsure at what points those two were introduced but it must be before or with hhvm 3.5.0 (discovered on travis-ci which runs this version at the moment).