### PR TITLE
Fix array to string conversion

### DIFF
--- a/src/Token/Stream.php
+++ b/src/Token/Stream.php
@@ -435,7 +435,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
                         $this->classes[$class[count($class)-1]]['methods'][$name] = $tmp;
 
                         $this->addFunctionToMap(
-                            $class . '::' . $name,
+                            $class[count($class)-1] . '::' . $name,
                             $tmp['startLine'],
                             $tmp['endLine']
                         );


### PR DESCRIPTION
`$class` in the current scope is an array, and can thus not be concatenated to a string.

Not sure if this should be `$class[0]` or something like `implode('\\', $class)`.