### PR TITLE
Fixing fatal error

### DIFF
--- a/src/Token/Stream.php
+++ b/src/Token/Stream.php
@@ -435,7 +435,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
                         $this->classes[$class[count($class)-1]]['methods'][$name] = $tmp;
 
                         $this->addFunctionToMap(
-                            $class . '::' . $name,
+                            $class[count($class)-1] . '::' . $name,
                             $tmp['startLine'],
                             $tmp['endLine']
                         );


### PR DESCRIPTION
Fixes "Fatal error: Uncaught exception 'PHPUnit_Framework_Error_Notice' with message 'Array to string conversion'" when running phpunit with code coverage.