### PR TITLE
Add support for HHVM - PHP_Token_SUPER

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -832,7 +832,7 @@ class PHP_Token_LAMBDA_CP extends PHP_Token {}
 class PHP_Token_LAMBDA_OP extends PHP_Token {}
 class PHP_Token_ONUMBER extends PHP_Token {}
 class PHP_Token_SHAPE extends PHP_Token {}
-class PHP_Token_SUPER extends PHP_TOKEN {}
+class PHP_Token_SUPER extends PHP_Token {}
 class PHP_Token_TYPE extends PHP_Token {}
 class PHP_Token_TYPELIST_GT extends PHP_Token {}
 class PHP_Token_TYPELIST_LT extends PHP_Token {}

--- a/src/Token.php
+++ b/src/Token.php
@@ -832,6 +832,7 @@ class PHP_Token_LAMBDA_CP extends PHP_Token {}
 class PHP_Token_LAMBDA_OP extends PHP_Token {}
 class PHP_Token_ONUMBER extends PHP_Token {}
 class PHP_Token_SHAPE extends PHP_Token {}
+class PHP_Token_SUPER extends PHP_TOKEN {}
 class PHP_Token_TYPE extends PHP_Token {}
 class PHP_Token_TYPELIST_GT extends PHP_Token {}
 class PHP_Token_TYPELIST_LT extends PHP_Token {}


### PR DESCRIPTION
Add support for PHP_Token_SUPER into HHVM

The problem:

```
Fatal error: Class undefined: PHP_Token_SUPER in vendor/phpunit/php-token-stream/src/Token/Stream.php on line 184
```