### PR TITLE
Backport of "use function" fix to 1.4

### DIFF
--- a/src/Token/Stream.php
+++ b/src/Token/Stream.php
@@ -176,6 +176,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
                     $name = 'CLASS_NAME_CONSTANT';
                 } elseif ($name == 'USE' && isset($tokens[$i+2][0]) && $tokens[$i+2][0] == T_FUNCTION) {
                     $name = 'USE_FUNCTION';
+                    $text .= $tokens[$i+1][1] . $tokens[$i+2][1];
                     $skip = 2;
                 }
 


### PR DESCRIPTION
I backported the change that fixed #69 to version 1.4 since it's in use in places where PHP 5.6 is still supported.