### PR TITLE
Catch an out of bounds exception when parsing an invalid file.

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -558,20 +558,25 @@ class PHP_Token_INTERFACE extends PHP_TokenWithScopeAndVisibility
      */
     public function getParent()
     {
-        if (!$this->hasParent()) {
+        try {
+            if (!$this->hasParent()) {
+                return false;
+            }
+
+            $i         = $this->id + 6;
+            $tokens    = $this->tokenStream->tokens();
+            $className = (string) $tokens[$i];
+
+            while (isset($tokens[$i + 1]) &&
+                   !$tokens[$i + 1] instanceof PHP_Token_WHITESPACE) {
+                $className .= (string) $tokens[++$i];
+            }
+
+            return $className;
+        } catch (OutOfBoundsException $e) {
+            // If the PHP file being parsed is syntactically invalid, this can happen (e.g. `<?php class C`
             return false;
         }
-
-        $i         = $this->id + 6;
-        $tokens    = $this->tokenStream->tokens();
-        $className = (string) $tokens[$i];
-
-        while (isset($tokens[$i + 1]) &&
-               !$tokens[$i + 1] instanceof PHP_Token_WHITESPACE) {
-            $className .= (string) $tokens[++$i];
-        }
-
-        return $className;
     }
 
     /**


### PR DESCRIPTION
The file being parsed was
https://github.com/phan/phan/blob/master/tests/misc/fallback_test/src/020_issue.php

- It was a file that previously crashed phan.

The invalid file wasn't being executed by the phpunit test suites,
but it did cause crashes when phpunit was figuring out what lines to
exclude, in places including the following:

- SebastianBergmann\CodeCoverage\CodeCoverage->getLinesToBeIgnored()
- SebastianBergmann\CodeCoverage\Node\File->processClasses()

A workaround for this bug is to add the `<directory />` to the `<exclude>` section of the whitelist, which I really should have been doing