### PR TITLE
getEndTokenId does not handle string-dollar "${var}" interpolation

### DIFF
--- a/src/Token.php
+++ b/src/Token.php
@@ -135,6 +135,7 @@ abstract class PHP_TokenWithScope extends PHP_Token
 
         while ($this->endTokenId === null && isset($tokens[$i])) {
             if ($tokens[$i] instanceof PHP_Token_OPEN_CURLY ||
+                $tokens[$i] instanceof PHP_Token_DOLLAR_OPEN_CURLY_BRACES ||
                 $tokens[$i] instanceof PHP_Token_CURLY_OPEN) {
                 $block++;
             } elseif ($tokens[$i] instanceof PHP_Token_CLOSE_CURLY) {

--- a/tests/Token/FunctionTest.php
+++ b/tests/Token/FunctionTest.php
@@ -74,6 +74,7 @@ class PHP_Token_FunctionTest extends TestCase
         $this->assertEquals(17, $this->functions[2]->getLine());
         $this->assertEquals(21, $this->functions[3]->getLine());
         $this->assertEquals(29, $this->functions[4]->getLine());
+        $this->assertEquals(37, $this->functions[6]->getLine());
     }
 
     /**
@@ -86,6 +87,7 @@ class PHP_Token_FunctionTest extends TestCase
         $this->assertEquals(19, $this->functions[2]->getEndLine());
         $this->assertEquals(23, $this->functions[3]->getEndLine());
         $this->assertEquals(31, $this->functions[4]->getEndLine());
+        $this->assertEquals(41, $this->functions[6]->getEndLine());
     }
 
     /**

--- a/tests/_fixture/source.php
+++ b/tests/_fixture/source.php
@@ -33,4 +33,10 @@ class Foo{function foo(){}
     public function blaz($x, $y)
     {
     }
+
+    public function buzz($foo)
+    {
+        echo "${foo}";
+        return true;
+    }
 }


### PR DESCRIPTION
There is a bug in the PHP_TokenWithScope::getEndTokenId function that manifests as coverage issues in PHPUnit.

The opening token of the string-dollar style variable interpolation "${var}" (PHP_Token_DOLLAR_OPEN_CURLY_BRACES) is not recognized by the function when determining block depth. This causes an off-by-one error and results in the next-to-last close brace being seen as the end line of the function. This cascades into php-code-coverage/PHPUnit as the end of the function being treated as ignored/non-executable.