### PR TITLE
use class-strings when possible

### DIFF
--- a/.psalm/config.xml
+++ b/.psalm/config.xml
@@ -22,7 +22,5 @@
 
         <DocblockTypeContradiction errorLevel="info" />
         <RedundantConditionGivenDocblockType errorLevel="info" />
-
-        <InvalidStringClass errorLevel="info" />
     </issueHandlers>
 </psalm>

--- a/src/Token.php
+++ b/src/Token.php
@@ -405,19 +405,19 @@ class PHP_Token_FUNCTION extends PHP_TokenWithScopeAndVisibility
         $tokens    = $this->tokenStream->tokens();
 
         for ($i = $this->id; $i <= $end; $i++) {
-            switch (PHP_Token_Util::getClass($tokens[$i])) {
-                case 'PHP_Token_IF':
-                case 'PHP_Token_ELSEIF':
-                case 'PHP_Token_FOR':
-                case 'PHP_Token_FOREACH':
-                case 'PHP_Token_WHILE':
-                case 'PHP_Token_CASE':
-                case 'PHP_Token_CATCH':
-                case 'PHP_Token_BOOLEAN_AND':
-                case 'PHP_Token_LOGICAL_AND':
-                case 'PHP_Token_BOOLEAN_OR':
-                case 'PHP_Token_LOGICAL_OR':
-                case 'PHP_Token_QUESTION_MARK':
+            switch (\get_class($tokens[$i])) {
+                case PHP_Token_IF::class:
+                case PHP_Token_ELSEIF::class:
+                case PHP_Token_FOR::class:
+                case PHP_Token_FOREACH::class:
+                case PHP_Token_WHILE::class:
+                case PHP_Token_CASE::class:
+                case PHP_Token_CATCH::class:
+                case PHP_Token_BOOLEAN_AND::class:
+                case PHP_Token_LOGICAL_AND::class:
+                case PHP_Token_BOOLEAN_OR::class:
+                case PHP_Token_LOGICAL_OR::class:
+                case PHP_Token_QUESTION_MARK::class:
                     $this->ccn++;
 
                     break;

--- a/src/Token/Stream.php
+++ b/src/Token/Stream.php
@@ -14,37 +14,37 @@
 class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
 {
     /**
-     * @var array
+     * @var array<string, class-string<PHP_Token>>
      */
     protected static $customTokens = [
-        '(' => 'PHP_Token_OPEN_BRACKET',
-        ')' => 'PHP_Token_CLOSE_BRACKET',
-        '[' => 'PHP_Token_OPEN_SQUARE',
-        ']' => 'PHP_Token_CLOSE_SQUARE',
-        '{' => 'PHP_Token_OPEN_CURLY',
-        '}' => 'PHP_Token_CLOSE_CURLY',
-        ';' => 'PHP_Token_SEMICOLON',
-        '.' => 'PHP_Token_DOT',
-        ',' => 'PHP_Token_COMMA',
-        '=' => 'PHP_Token_EQUAL',
-        '<' => 'PHP_Token_LT',
-        '>' => 'PHP_Token_GT',
-        '+' => 'PHP_Token_PLUS',
-        '-' => 'PHP_Token_MINUS',
-        '*' => 'PHP_Token_MULT',
-        '/' => 'PHP_Token_DIV',
-        '?' => 'PHP_Token_QUESTION_MARK',
-        '!' => 'PHP_Token_EXCLAMATION_MARK',
-        ':' => 'PHP_Token_COLON',
-        '"' => 'PHP_Token_DOUBLE_QUOTES',
-        '@' => 'PHP_Token_AT',
-        '&' => 'PHP_Token_AMPERSAND',
-        '%' => 'PHP_Token_PERCENT',
-        '|' => 'PHP_Token_PIPE',
-        '$' => 'PHP_Token_DOLLAR',
-        '^' => 'PHP_Token_CARET',
-        '~' => 'PHP_Token_TILDE',
-        '`' => 'PHP_Token_BACKTICK',
+        '(' => PHP_Token_OPEN_BRACKET::class,
+        ')' => PHP_Token_CLOSE_BRACKET::class,
+        '[' => PHP_Token_OPEN_SQUARE::class,
+        ']' => PHP_Token_CLOSE_SQUARE::class,
+        '{' => PHP_Token_OPEN_CURLY::class,
+        '}' => PHP_Token_CLOSE_CURLY::class,
+        ';' => PHP_Token_SEMICOLON::class,
+        '.' => PHP_Token_DOT::class,
+        ',' => PHP_Token_COMMA::class,
+        '=' => PHP_Token_EQUAL::class,
+        '<' => PHP_Token_LT::class,
+        '>' => PHP_Token_GT::class,
+        '+' => PHP_Token_PLUS::class,
+        '-' => PHP_Token_MINUS::class,
+        '*' => PHP_Token_MULT::class,
+        '/' => PHP_Token_DIV::class,
+        '?' => PHP_Token_QUESTION_MARK::class,
+        '!' => PHP_Token_EXCLAMATION_MARK::class,
+        ':' => PHP_Token_COLON::class,
+        '"' => PHP_Token_DOUBLE_QUOTES::class,
+        '@' => PHP_Token_AT::class,
+        '&' => PHP_Token_AMPERSAND::class,
+        '%' => PHP_Token_PERCENT::class,
+        '|' => PHP_Token_PIPE::class,
+        '$' => PHP_Token_DOLLAR::class,
+        '^' => PHP_Token_CARET::class,
+        '~' => PHP_Token_TILDE::class,
+        '`' => PHP_Token_BACKTICK::class,
     ];
 
     /**
@@ -241,11 +241,11 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
             ];
 
             foreach ($this->tokens as $token) {
-                switch (PHP_Token_Util::getClass($token)) {
-                    case 'PHP_Token_REQUIRE_ONCE':
-                    case 'PHP_Token_REQUIRE':
-                    case 'PHP_Token_INCLUDE_ONCE':
-                    case 'PHP_Token_INCLUDE':
+                switch (\get_class($token)) {
+                    case PHP_Token_REQUIRE_ONCE::class:
+                    case PHP_Token_REQUIRE::class:
+                    case PHP_Token_INCLUDE_ONCE::class:
+                    case PHP_Token_INCLUDE::class:
                         $this->includes[$token->getType()][] = $token->getName();
 
                         break;
@@ -435,6 +435,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
                     $skip = 2;
                 }
 
+                /** @var class-string<PHP_Token> $tokenClass */
                 $tokenClass = 'PHP_Token_' . $name;
             } else {
                 $text       = $token;
@@ -445,12 +446,12 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
             $lines          = \substr_count($text, "\n");
             $line += $lines;
 
-            if ($tokenClass == 'PHP_Token_HALT_COMPILER') {
+            if ($tokenClass == PHP_Token_HALT_COMPILER::class) {
                 break;
             }
 
-            if ($tokenClass == 'PHP_Token_COMMENT' ||
-                $tokenClass == 'PHP_Token_DOC_COMMENT') {
+            if ($tokenClass == PHP_Token_COMMENT::class ||
+                $tokenClass == PHP_Token_DOC_COMMENT::class) {
                 $this->linesOfCode['cloc'] += $lines + 1;
             }
 
@@ -482,11 +483,11 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
         $interfaceEndLine = false;
 
         foreach ($this->tokens as $token) {
-            switch (PHP_Token_Util::getClass($token)) {
-                case 'PHP_Token_HALT_COMPILER':
+            switch (\get_class($token)) {
+                case PHP_Token_HALT_COMPILER::class:
                     return;
 
-                case 'PHP_Token_INTERFACE':
+                case PHP_Token_INTERFACE::class:
                     $interface        = $token->getName();
                     $interfaceEndLine = $token->getEndLine();
 
@@ -503,8 +504,8 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
 
                     break;
 
-                case 'PHP_Token_CLASS':
-                case 'PHP_Token_TRAIT':
+                case PHP_Token_CLASS::class:
+                case PHP_Token_TRAIT::class:
                     $tmp = [
                         'methods'   => [],
                         'parent'    => $token->getParent(),
@@ -532,7 +533,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
 
                     break;
 
-                case 'PHP_Token_FUNCTION':
+                case PHP_Token_FUNCTION::class:
                     $name = $token->getName();
                     $tmp  = [
                         'docblock'  => $token->getDocblock(),
@@ -577,7 +578,7 @@ class PHP_Token_Stream implements ArrayAccess, Countable, SeekableIterator
 
                     break;
 
-                case 'PHP_Token_CLOSE_CURLY':
+                case PHP_Token_CLOSE_CURLY::class:
                     if (!empty($classEndLine) &&
                         $classEndLine[\count($classEndLine) - 1] == $token->getLine()) {
                         \array_pop($classEndLine);


### PR DESCRIPTION
This PR is the continuation of the splitting of #90

This one replace strings representing classes and use the ::class syntax. This also helps Psalm figuring what those strings are and allow removing InvalidStringClass from Psalm's config