### PR TITLE
Fix getVisibility() for methods without keyword

### DIFF
--- a/src/TokenWithScopeAndVisibility.php
+++ b/src/TokenWithScopeAndVisibility.php
@@ -34,6 +34,8 @@ abstract class PHP_TokenWithScopeAndVisibility extends PHP_TokenWithScope
                 break;
             }
         }
+
+        return 'public';
     }
 
     /**

--- a/tests/Token/FunctionTest.php
+++ b/tests/Token/FunctionTest.php
@@ -123,4 +123,17 @@ class PHP_Token_FunctionTest extends TestCase
             $interfaces['i']['methods']['m']['signature']
         );
     }
+
+    public function testVisibility(): void
+    {
+        $this->assertEquals('public', $this->functions[0]->getVisibility());
+        $this->assertEquals('public', $this->functions[1]->getVisibility());
+        $this->assertEquals('public', $this->functions[2]->getVisibility());
+        $this->assertEquals('public', $this->functions[3]->getVisibility());
+        $this->assertEquals('public', $this->functions[4]->getVisibility());
+        $this->assertEquals('public', $this->functions[5]->getVisibility());
+        $this->assertEquals('public', $this->functions[6]->getVisibility());
+        $this->assertEquals('protected', $this->functions[7]->getVisibility());
+        $this->assertEquals('private', $this->functions[8]->getVisibility());
+    }
 }

--- a/tests/_fixture/source.php
+++ b/tests/_fixture/source.php
@@ -39,4 +39,12 @@ class Foo{function foo(){}
         echo "${foo}";
         return true;
     }
+
+    protected function qux()
+    {
+    }
+
+    private function quux()
+    {
+    }
 }


### PR DESCRIPTION
Methods declared without any explicit visibility keyword are defined as public